### PR TITLE
fix ChainChoices default dtype from str to int

### DIFF
--- a/dexguru_sdk/models/choices.py
+++ b/dexguru_sdk/models/choices.py
@@ -23,7 +23,7 @@ class AmmChoices(str, Enum, metaclass=ContaineredEnum):
     quickswap = 'quickswap'
 
 
-class ChainChoices(str, Enum, metaclass=ContaineredEnum):
+class ChainChoices(int, Enum, metaclass=ContaineredEnum):
     eth = 1
     bsc = 56
     polygon = 137

--- a/dexguru_sdk/models/choices.py
+++ b/dexguru_sdk/models/choices.py
@@ -21,12 +21,18 @@ class AmmChoices(str, Enum, metaclass=ContaineredEnum):
     pancakeswap = 'pancakeswap'
     sushiswap = 'sushiswap'
     quickswap = 'quickswap'
+    spiritswap = 'spiritswap'
+    spookyswap = 'spookyswap'
+    traderjoe = 'traderjoe'
+    pangolin = 'pangolin'
 
 
 class ChainChoices(int, Enum, metaclass=ContaineredEnum):
     eth = 1
     bsc = 56
     polygon = 137
+    fantom = 250
+    avalanche = 43114
 
 
 class TransactionChoices(str, Enum, metaclass=ContaineredEnum):


### PR DESCRIPTION
the default return value type of `chain_id` is `int`, while the `models.ChainChoices` is set to inherit from `str`, `Enum`, `ContaineredEnum`
