### PR TITLE
add more chain choices

### DIFF
--- a/dexguru_sdk/models/choices.py
+++ b/dexguru_sdk/models/choices.py
@@ -34,13 +34,16 @@ class AmmChoices(str, Enum, metaclass=ContaineredEnum):
 
 class ChainChoices(int, Enum, metaclass=ContaineredEnum):
     eth = 1
+    optimism = 10
     bsc = 56
+    gnosis = 100
     polygon = 137
     fantom = 250
-    avalanche = 43114
     arbitrum = 42161
     celo = 42220
-
+    avalanche = 43114
+    nova = 42170
+    canto = 7700
 
 class TransactionChoices(str, Enum, metaclass=ContaineredEnum):
     swap = 'swap'


### PR DESCRIPTION
Fresh chain choices are based on response of [`get_chains`](https://github.com/dex-guru/dg-sdk-python/blob/main/dexguru_sdk/sdk/dg_sdk.py#L34) method.